### PR TITLE
Field should not rely on author ID. Fixes #31.

### DIFF
--- a/fields/field.email_newsletter_manager.php
+++ b/fields/field.email_newsletter_manager.php
@@ -665,10 +665,10 @@
 			// save
 			$author_id = 0;
 			$Members = Symphony::ExtensionManager()->create('members');
-			if(is_object(Symphony::Engine()->Author)){
-				$author_id = Symphony::Engine()->Author->get('id');
+			if(Symphony::Engine() instanceof Administration){
+				$author_id = Administration::instance()->Author->get('id');
 			}
-			elseif(is_object($Members->getMemberDriver())){
+			elseif(Symphony::Engine() instanceof Frontend && is_object($Members->getMemberDriver())){
 				$author_id = $Members->getMemberDriver()->getMemberID();
 			}
 			$newsletter = EmailNewsletterManager::save(array(


### PR DESCRIPTION
This is probably a good fix for issue #31 if we want to keep the "author id/created by" functionality of the ENM field. Nevertheless, please take a look!
